### PR TITLE
Fix buffer size configuration to use NMEA2000 library settings

### DIFF
--- a/NMEA2000_esp32xx.cpp
+++ b/NMEA2000_esp32xx.cpp
@@ -378,6 +378,6 @@ void tNMEA2000_esp32xx::loop()
     if (logTimer.IsTime())
     {
         logTimer.UpdateNextTime();
-        //logStatus();
+        logStatus();
     }
 }

--- a/NMEA2000_esp32xx.cpp
+++ b/NMEA2000_esp32xx.cpp
@@ -234,8 +234,9 @@ void tNMEA2000_esp32xx::InitCANFrameBuffers()
     else
     {
         twai_general_config_t g_config = TWAI_GENERAL_CONFIG_DEFAULT((gpio_num_t)TxPin, (gpio_num_t)RxPin, TWAI_MODE_NORMAL);
-        g_config.tx_queue_len = 20;
-        g_config.rx_queue_len = 40;                  // need a large Rx buffer to prevent rxmiss
+        // Use configured buffer sizes, with reasonable defaults if not set
+        g_config.tx_queue_len = (MaxCANSendFrames > 0) ? MaxCANSendFrames : 80;  // Default 80 for burst handling
+        g_config.rx_queue_len = MaxCANReceiveFrames;  // Use configured buffer size instead of hardcoded 40
         g_config.intr_flags |= ESP_INTR_FLAG_LOWMED; // LOWMED might be needed if you run out of LEVEL1 interrupts.
 
         twai_timing_config_t t_config;
@@ -377,6 +378,6 @@ void tNMEA2000_esp32xx::loop()
     if (logTimer.IsTime())
     {
         logTimer.UpdateNextTime();
-        logStatus();
+        //logStatus();
     }
 }


### PR DESCRIPTION
- Use MaxCANReceiveFrames instead of hardcoded 40 for RX buffer
- Use MaxCANSendFrames for TX buffer with fallback to 80 frames
- Fixes message loss during rapid command bursts (e.g. 'All RGB Lights')
- Improves handling of 126208 command responses and 130561 status messages
- Allows proper configuration via SetN2kCANReceiveFrameBufSize() and SetN2kCANSendFrameBufSize()

Resolves issues where ESP32 driver ignored NMEA2000 library buffer configuration.